### PR TITLE
HADOOP-16820. [thirdparty] ChangeLog and ReleaseNote are not packaged by createrelease script

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -551,12 +551,12 @@ function makearelease
 
   # Stage CHANGELOG and RELEASENOTES files
   for i in CHANGELOG RELEASENOTES; do
-    if [[ $(ls -l "${BASEDIR}/src/site/markdown/release/${HADOOP_THIRDPARTY_VERSION}"/${i}*.md | wc -l) == 0 ]]; then
+    if [[ $(ls -l "${BASEDIR}/src/site/markdown/release/thirdparty-${HADOOP_THIRDPARTY_VERSION}"/${i}*.md | wc -l) == 0 ]]; then
       echo "No ${i} found. Continuing..."
       continue;
     fi
     run cp -p \
-        "${BASEDIR}/src/site/markdown/release/${HADOOP_THIRDPARTY_VERSION}"/${i}*.md \
+        "${BASEDIR}/src/site/markdown/release/thirdparty-${HADOOP_THIRDPARTY_VERSION}"/${i}*.md \
         "${ARTIFACTS_DIR}/${i}.md"
   done
 

--- a/dev-support/bin/yetus-wrapper
+++ b/dev-support/bin/yetus-wrapper
@@ -176,6 +176,15 @@ if ! (gunzip -c "${TARBALL}.gz" | tar xpf -); then
   exit 1
 fi
 
+if [[ "${WANTED}" == "releasedocmaker" ]]; then
+  # releasedocmaker expects versions to be in form of x.y.z to generate index and readme files.
+  # But thirdparty version will be in form of 'thirdparty-x.y.z'
+  if [[ -x "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/lib/releasedocmaker/releasedocmaker/__init__.py" ]]; then
+    sed -i 's@glob(\"@glob(\"thirdparty-@g' "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/lib/releasedocmaker/releasedocmaker/__init__.py"
+    sed -i 's@%s v%s@%s %s@g' "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/lib/releasedocmaker/releasedocmaker/__init__.py"
+  fi
+fi
+
 if [[ -x "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/bin/${WANTED}" ]]; then
   popd >/dev/null
   exec "${HADOOP_PATCHPROCESS}/${YETUS_PREFIX}-${HADOOP_YETUS_VERSION}/bin/${WANTED}" "${ARGV[@]}"


### PR DESCRIPTION
# Changes
ChangeLog and ReleaseNotes were not included due to version change.
Hadoop thirdparty module have versions in form of "thirdparty-x.y.z", but script expects in "x.y.z" format.
