### PR TITLE
HADOOP-16867. [thirdparty] Add shaded JaegerTracer

### DIFF
--- a/hadoop-jaeger/pom.xml
+++ b/hadoop-jaeger/pom.xml
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>hadoop-thirdparty</artifactId>
+        <groupId>org.apache.hadoop.thirdparty</groupId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>hadoop-jaeger</artifactId>
+
+    <name>Apache Hadoop shaded JaegerTracer</name>
+    <packaging>jar</packaging>
+
+    <properties>
+        <jaegertracing.version>0.34.2</jaegertracing.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-client</artifactId>
+            <version>${jaegertracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.jaegertracing</groupId>
+            <artifactId>jaeger-thrift</artifactId>
+            <version>${jaegertracing.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.thrift</groupId>
+            <artifactId>libthrift</artifactId>
+            <version>0.13.0</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <!--Make it so assembly:single does nothing in here-->
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <configuration>
+                        <skipAssembly>true</skipAssembly>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-shade-plugin</artifactId>
+                    <executions>
+                        <execution>
+                            <id>aggregate-into-a-jar-with-relocated-third-parties</id>
+                            <phase>package</phase>
+                            <goals>
+                                <goal>shade</goal>
+                            </goals>
+                            <configuration>
+                                <createSourcesJar>false</createSourcesJar>
+                                <shadedArtifactAttached>false</shadedArtifactAttached>
+                                <shadeTestJar>false</shadeTestJar>
+
+                                <artifactSet>
+                                    <excludes>
+                                        <exclude>org.apache.httpcomponents:httpclient</exclude>
+                                        <exclude>commons-logging:commons-logging</exclude>
+                                        <exclude>commons-codec:commons-codec</exclude>
+                                        <exclude>org.apache.httpcomponents:httpcore</exclude>
+                                        <exclude>javax.annotation:javax.annotation-api</exclude>
+                                        <exclude>org.slf4j:slf4j-api</exclude>
+                                        <exclude>io.opentracing:*</exclude>
+                                    </excludes>
+                                </artifactSet>
+
+                                <relocations>
+                                    <!-- shade gson, which is transitively included via jaeger-core -->
+                                    <relocation>
+                                        <pattern>com.google.gson</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.com.google.gson</shadedPattern>
+                                    </relocation>
+
+                                    <!-- shade jaeger-thrift and its dependencies -->
+                                    <relocation>
+                                        <pattern>io.jaegertracing.thriftjava</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.thriftjava</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>io.jaegertracing.crossdock</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.crossdock</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>io.jaegertracing.thrift</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.thrift</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>io.jaegertracing.agent</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.agent</shadedPattern>
+                                    </relocation>
+
+                                    <relocation>
+                                        <pattern>org.apache.thrift</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.apache.thrift</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>com.twitter.zipkin</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.com.twitter.zipkin</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>okhttp3</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.okhttp3</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>kotlin</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.kotlin</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>org.intellij</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.org.intellij</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                        <pattern>org.jetbrains</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.org.jetbrains</shadedPattern>
+                                    </relocation>
+                                    <!-- top level okio -->
+                                    <relocation>
+                                        <pattern>okio</pattern>
+                                        <shadedPattern>${shaded.prefix}.io.jaegertracing.okio</shadedPattern>
+                                    </relocation>
+
+                                </relocations>
+                                <transformers>
+                                    <!-- Need to filter out some extraneous license files.
+                                         Don't use the ApacheLicenseRT because it just removes all
+                                         META-INF/LICENSE(.txt)? files, including ours. -->
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.DontIncludeResourceTransformer">
+                                        <resources>
+                                            <resource>LICENSE.txt</resource>
+                                            <resource>ASL2.0</resource>
+                                            <!-- also this unneeded doc -->
+                                            <resource>overview.html</resource>
+                                        </resources>
+                                    </transformer>
+                                    <!-- Where notices exist, just concat them -->
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                                        <addHeader>false</addHeader>
+                                        <projectName>${project.name}</projectName>
+                                    </transformer>
+                                    <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer">
+                                    </transformer>
+                                </transformers>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+        <plugins>
+            <plugin>
+                <!--Make it so assembly:single does nothing in here-->
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <skipAssembly>true</skipAssembly>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/hadoop-shaded-jaeger/pom.xml
+++ b/hadoop-shaded-jaeger/pom.xml
@@ -1,4 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/hadoop-shaded-jaeger/pom.xml
+++ b/hadoop-shaded-jaeger/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
-    <artifactId>hadoop-jaeger</artifactId>
+    <artifactId>hadoop-shaded-jaeger</artifactId>
 
     <name>Apache Hadoop shaded JaegerTracer</name>
     <packaging>jar</packaging>

--- a/hadoop-shaded-jaeger/pom.xml
+++ b/hadoop-shaded-jaeger/pom.xml
@@ -24,16 +24,6 @@
             <artifactId>jaeger-client</artifactId>
             <version>${jaegertracing.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.jaegertracing</groupId>
-            <artifactId>jaeger-thrift</artifactId>
-            <version>${jaegertracing.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.thrift</groupId>
-            <artifactId>libthrift</artifactId>
-            <version>0.13.0</version>
-        </dependency>
     </dependencies>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,6 +122,7 @@
 
   <modules>
     <module>hadoop-shaded-protobuf_3_7</module>
+    <module>hadoop-jaeger</module>
   </modules>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
 
   <modules>
     <module>hadoop-shaded-protobuf_3_7</module>
-    <module>hadoop-jaeger</module>
+    <module>hadoop-shaded-jaeger</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Add artifact hadoop-shaded-jaeger to hadoop-thirdparty for OpenTracing work (HADOOP-15566).

With this commit in thirdparty, Hadoop trunk with HADOOP-15566 can pass the enforcer check.