### PR TITLE
HADOOP-17679. Upgrade Protobuf to 3.17.3

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -216,7 +216,7 @@ See licenses-binary/ for text of these licenses.
 
 BSD 3-Clause
 ------------
-com.google.protobuf:protobuf-java:3.12.4
+com.google.protobuf:protobuf-java:3.17.0
 
 
 MIT License

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -216,7 +216,7 @@ See licenses-binary/ for text of these licenses.
 
 BSD 3-Clause
 ------------
-com.google.protobuf:protobuf-java:3.17.0
+com.google.protobuf:protobuf-java:3.17.3
 
 
 MIT License

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -216,7 +216,7 @@ See licenses-binary/ for text of these licenses.
 
 BSD 3-Clause
 ------------
-com.google.protobuf:protobuf-java:3.7.1
+com.google.protobuf:protobuf-java:3.12.4
 
 
 MIT License

--- a/hadoop-shaded-protobuf_3_12/pom.xml
+++ b/hadoop-shaded-protobuf_3_12/pom.xml
@@ -27,8 +27,8 @@
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
-  <name>Apache Hadoop shaded Protobuf 3.7</name>
+  <artifactId>hadoop-shaded-protobuf_3_12</artifactId>
+  <name>Apache Hadoop shaded Protobuf 3.12</name>
   <packaging>jar</packaging>
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf_3_7.version}</version>
+      <version>${protobuf_3_12.version}</version>
     </dependency>
   </dependencies>
 

--- a/hadoop-shaded-protobuf_3_17/pom.xml
+++ b/hadoop-shaded-protobuf_3_17/pom.xml
@@ -27,8 +27,8 @@
     <relativePath>..</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>hadoop-shaded-protobuf_3_12</artifactId>
-  <name>Apache Hadoop shaded Protobuf 3.12</name>
+  <artifactId>hadoop-shaded-protobuf_3_17</artifactId>
+  <name>Apache Hadoop shaded Protobuf 3.17</name>
   <packaging>jar</packaging>
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf_3_12.version}</version>
+      <version>${protobuf_3_17.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!--thirdparty dependency versions-->
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-    <protobuf_3_17.version>3.17.0</protobuf_3_17.version>
+    <protobuf_3_17.version>3.17.3</protobuf_3_17.version>
     <guava.version>30.1.1-jre</guava.version>
 
     <!-- maven plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!--thirdparty dependency versions-->
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-    <protobuf_3_12.version>3.12.4</protobuf_3_12.version>
+    <protobuf_3_17.version>3.17.0</protobuf_3_17.version>
     <guava.version>30.1.1-jre</guava.version>
 
     <!-- maven plugin versions -->
@@ -122,7 +122,7 @@
   </organization>
 
   <modules>
-    <module>hadoop-shaded-protobuf_3_12</module>
+    <module>hadoop-shaded-protobuf_3_17</module>
     <module>hadoop-shaded-guava</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!--thirdparty dependency versions-->
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-    <protobuf_3_7.version>3.7.1</protobuf_3_7.version>
+    <protobuf_3_12.version>3.12.4</protobuf_3_12.version>
     <guava.version>30.1.1-jre</guava.version>
 
     <!-- maven plugin versions -->
@@ -122,7 +122,7 @@
   </organization>
 
   <modules>
-    <module>hadoop-shaded-protobuf_3_7</module>
+    <module>hadoop-shaded-protobuf_3_12</module>
     <module>hadoop-shaded-guava</module>
   </modules>
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -42,7 +42,7 @@ This page provides an overview of the major changes.
 
 Protobuf-java
 -------------
-Google Protobuf's 3.17.0 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_17* artifact.
+Google Protobuf's 3.17.3 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_17* artifact.
 
 Following are relocations under *hadoop-shaded-protobuf_3_17* artifact:
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -42,9 +42,9 @@ This page provides an overview of the major changes.
 
 Protobuf-java
 -------------
-Google Protobuf's 3.7.1 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7* artifact.
+Google Protobuf's 3.12.4 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_12* artifact.
 
-Following are relocations under *hadoop-shaded-protobuf_3_7* artifact:
+Following are relocations under *hadoop-shaded-protobuf_3_12* artifact:
 
 |Original package | Shaded package |
 |---|---|

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -42,9 +42,9 @@ This page provides an overview of the major changes.
 
 Protobuf-java
 -------------
-Google Protobuf's 3.12.4 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_12* artifact.
+Google Protobuf's 3.17.0 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_17* artifact.
 
-Following are relocations under *hadoop-shaded-protobuf_3_12* artifact:
+Following are relocations under *hadoop-shaded-protobuf_3_17* artifact:
 
 |Original package | Shaded package |
 |---|---|

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -59,15 +59,5 @@ Following are relocations under *hadoop-shaded-guava* artifact:
 
 |Original package | Shaded package |
 |---|---|
-|com.google.gson | org.apache.hadoop.thirdparty.io.jaegertracing.com.google.gson|
-|io.jaegertracing.thriftjava|org.apache.hadoop.thirdparty.io.jaegertracing.thriftjava|
-|io.jaegertracing.crossdock|org.apache.hadoop.thirdparty.io.jaegertracing.crossdock|
-|io.jaegertracing.thrift|org.apache.hadoop.thirdparty.io.jaegertracing.thrift|
-|io.jaegertracing.agent|org.apache.hadoop.thirdparty.io.jaegertracing.agent|
-|org.apache.thrift|org.apache.hadoop.thirdparty.io.jaegertracing.apache.thrift|
-|com.twitter.zipkin|org.apache.hadoop.thirdparty.io.jaegertracing.com.twitter.zipkin|
-|okhttp3|org.apache.hadoop.thirdparty.io.jaegertracing.okhttp3|
-|kotlin|org.apache.hadoop.thirdparty.io.jaegertracing.kotlin|
-|org.intellij|org.apache.hadoop.thirdparty.io.jaegertracing.org.intellij|
-|org.jetbrains|org.apache.hadoop.thirdparty.io.jaegertracing.org.jetbrains|
-|okio|org.apache.hadoop.thirdparty.io.jaegertracing.okio|
+|com.google|org.apache.hadoop.thirdparty.com.google|
+|org.checkerframework|org.apache.hadoop.thirdparty.org.checkerframework|


### PR DESCRIPTION
Protobuf 3.17.3 is the latest Protobuf release now.