### PR TITLE
HADOOP-17692. [thirdparty] Fix the docker image

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -59,8 +59,6 @@ RUN apt-get -q update \
         libbz2-dev \
         libcurl4-openssl-dev \
         libfuse-dev \
-        libprotobuf-dev \
-        libprotoc-dev \
         libsasl2-dev \
         libssl-dev \
         libtool \
@@ -93,23 +91,6 @@ RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends openjdk-8-jdk libbcprov-java \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
-
-######
-# Install Google Protobuf 3.7.1 (3.0.0 ships with Bionic)
-######
-# hadolint ignore=DL3003
-RUN mkdir -p /opt/protobuf-src \
-    && curl -L -s -S \
-      https://github.com/protocolbuffers/protobuf/releases/download/v3.7.1/protobuf-java-3.7.1.tar.gz \
-      -o /opt/protobuf.tar.gz \
-    && tar xzf /opt/protobuf.tar.gz --strip-components 1 -C /opt/protobuf-src \
-    && cd /opt/protobuf-src \
-    && ./configure --prefix=/opt/protobuf \
-    && make install \
-    && cd /root \
-    && rm -rf /opt/protobuf-src
-ENV PROTOBUF_HOME /opt/protobuf
-ENV PATH "${PATH}:/opt/protobuf/bin"
 
 ######
 # Install Apache Maven 3.6.0 (3.6.0 ships with Bionic)

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -18,7 +18,7 @@
 # Dockerfile for installing the necessary dependencies for building Hadoop.
 # See BUILDING.txt.
 
-FROM ubuntu:xenial
+FROM ubuntu:bionic
 
 WORKDIR /root
 
@@ -44,9 +44,11 @@ ENV DEBCONF_TERSE true
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends \
         apt-utils \
+        bats \
         build-essential \
         bzip2 \
         clang \
+        cmake \
         curl \
         doxygen \
         fuse \
@@ -60,7 +62,6 @@ RUN apt-get -q update \
         libprotobuf-dev \
         libprotoc-dev \
         libsasl2-dev \
-        libsnappy-dev \
         libssl-dev \
         libtool \
         libzstd1-dev \
@@ -75,8 +76,8 @@ RUN apt-get -q update \
         python-setuptools \
         python-wheel \
         rsync \
+        shellcheck \
         software-properties-common \
-        snappy \
         sudo \
         valgrind \
         zlib1g-dev \
@@ -93,20 +94,8 @@ RUN apt-get -q update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-
 ######
-# Install cmake 3.1.0 (3.5.1 ships with Xenial)
-######
-RUN mkdir -p /opt/cmake \
-    && curl -L -s -S \
-      https://cmake.org/files/v3.1/cmake-3.1.0-Linux-x86_64.tar.gz \
-      -o /opt/cmake.tar.gz \
-    && tar xzf /opt/cmake.tar.gz --strip-components 1 -C /opt/cmake
-ENV CMAKE_HOME /opt/cmake
-ENV PATH "${PATH}:/opt/cmake/bin"
-
-######
-# Install Google Protobuf 3.7.1 (2.6.0 ships with Xenial)
+# Install Google Protobuf 3.7.1 (3.0.0 ships with Bionic)
 ######
 # hadolint ignore=DL3003
 RUN mkdir -p /opt/protobuf-src \
@@ -123,7 +112,7 @@ ENV PROTOBUF_HOME /opt/protobuf
 ENV PATH "${PATH}:/opt/protobuf/bin"
 
 ######
-# Install Apache Maven 3.3.9 (3.3.9 ships with Xenial)
+# Install Apache Maven 3.6.0 (3.6.0 ships with Bionic)
 ######
 # hadolint ignore=DL3008
 RUN apt-get -q update \
@@ -131,9 +120,11 @@ RUN apt-get -q update \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 ENV MAVEN_HOME /usr
+# JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
 
 ######
-# Install findbugs 3.0.1 (3.0.1 ships with Xenial)
+# Install findbugs 3.1.0 (3.1.0 ships with Bionic)
 # Ant is needed for findbugs
 ######
 # hadolint ignore=DL3008
@@ -144,46 +135,20 @@ RUN apt-get -q update \
 ENV FINDBUGS_HOME /usr
 
 ####
-# Install shellcheck (0.4.6, the latest as of 2017-09-26)
-####
-# hadolint ignore=DL3008
-RUN add-apt-repository -y ppa:hvr/ghc \
-    && apt-get -q update \
-    && apt-get -q install -y --no-install-recommends shellcheck ghc-8.0.2 \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-####
-# Install bats (0.4.0, the latest as of 2017-09-26, ships with Xenial)
-####
-# hadolint ignore=DL3008
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends bats \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-
-####
 # Install pylint at fixed version (2.0.0 removed python2 support)
 # https://github.com/PyCQA/pylint/issues/2294
+#
+# weichiu: as of 05/12/2021, downloading pylint downloads isort>=4.2.5 which
+# points to isort 5.8.0 whic doesn't support python 2.7.
+# Instead, download the last isort 4.x version.
 ####
+RUN pip2 install isort==4.3.21
 RUN pip2 install pylint==1.9.2
 
 ####
 # Install dateutil.parser
 ####
 RUN pip2 install python-dateutil==2.7.3
-
-###
-# Install node.js for web UI framework (4.2.6 ships with Xenial)
-###
-# hadolint ignore=DL3008, DL3016
-RUN apt-get -q update \
-    && apt-get install -y --no-install-recommends nodejs npm \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* \
-    && ln -s /usr/bin/nodejs /usr/bin/node \
-    && npm install npm@latest -g \
-    && npm install -g jshint
 
 ###
 # Install hadolint


### PR DESCRIPTION
(1) Hard code a python dependency version to avoid image build error.
(2) Remove npm which is not used for building hadoop-thirdparty to avoid image build error.
(3) Migrate to Ubuntu 18.04 (Bionic) to use GPG 2.2 (LTS) instead of 1.x for signing.
The build script runs a gpg agent inside docker that shares the gpg keys with the host machine, of which most ships GPG2.2. GPG 1.x is quite old and is not compatible with GPG 2.x. Ubuntu 16.04 (Xenia) has gpg2.1 packages, which is incompatible with gpg2.2. Ubuntu 18.04 installs gpg 2.2 by default. 

The Bionic migration is based on HADOOP-16054 https://github.com/apache/hadoop/commit/81d8b71534645a2109a037115fb955351edfbf64

Test: manually tested by running `dev-support/bin/create-release --asfrelease --docker --dockercache`