### PR TITLE
HADOOP-17697. Fix license error in GitHub Actions workflow files.

### DIFF
--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -1,3 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
 name: Dependency check
 
 on: [push, pull_request]

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -15,7 +15,7 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: Build
+name: License check
 
 on: [push, pull_request]
 
@@ -30,6 +30,11 @@ jobs:
       with:
         java-version: '8'
         distribution: 'adopt'
-    - name: Build with Maven
-      run: mvn install
+    - name: License check with Maven
+      run: mvn apache-rat:check
+    - name: Upload the report
+      uses: actions/upload-artifact@v2
+      with:
+        name: license-check-report
+        path: "**/target/rat.txt"
 


### PR DESCRIPTION
JIRA: HADOOP-17697

- Added the license header
- Create a job to check license