### PR TITLE
HADOOP-17707. Remove jaeger document from site index.

### DIFF
--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -49,3 +49,14 @@ Following are relocations under *hadoop-shaded-protobuf_3_7* artifact:
 |Original package | Shaded package |
 |---|---|
 |com.google.protobuf|org.apache.hadoop.thirdparty.protobuf|
+
+
+Guava
+-------------
+Google Guava's 30.1.1 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-guava* artifact.
+
+Following are relocations under *hadoop-shaded-guava* artifact:
+
+|Original package | Shaded package |
+|---|---|
+|com.google.guava|org.apache.hadoop.thirdparty.com.google.common|

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -60,3 +60,4 @@ Following are relocations under *hadoop-shaded-guava* artifact:
 |Original package | Shaded package |
 |---|---|
 |com.google.guava|org.apache.hadoop.thirdparty.com.google|
+|org.checkerframework|org.apache.hadoop.thirdparty.org.checkerframework|

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -59,4 +59,4 @@ Following are relocations under *hadoop-shaded-guava* artifact:
 
 |Original package | Shaded package |
 |---|---|
-|com.google.guava|org.apache.hadoop.thirdparty.com.google.common|
+|com.google.guava|org.apache.hadoop.thirdparty.com.google|

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -49,25 +49,3 @@ Following are relocations under *hadoop-shaded-protobuf_3_7* artifact:
 |Original package | Shaded package |
 |---|---|
 |com.google.protobuf|org.apache.hadoop.thirdparty.protobuf|
-
-
-io.jaegertracing:jaeger-client
-------------------------------
-jaeger-client: 0.34.2 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-jaeger* artifact.
-
-Following are relocations under *hadoop-shaded-jaeger* artifact:
-
-|Original package | Shaded package |
-|---|---|
-|com.google.gson | org.apache.hadoop.thirdparty.io.jaegertracing.com.google.gson|
-|io.jaegertracing.thriftjava|org.apache.hadoop.thirdparty.io.jaegertracing.thriftjava|
-|io.jaegertracing.crossdock|org.apache.hadoop.thirdparty.io.jaegertracing.crossdock|
-|io.jaegertracing.thrift|org.apache.hadoop.thirdparty.io.jaegertracing.thrift|
-|io.jaegertracing.agent|org.apache.hadoop.thirdparty.io.jaegertracing.agent|
-|org.apache.thrift|org.apache.hadoop.thirdparty.io.jaegertracing.apache.thrift|
-|com.twitter.zipkin|org.apache.hadoop.thirdparty.io.jaegertracing.com.twitter.zipkin|
-|okhttp3|org.apache.hadoop.thirdparty.io.jaegertracing.okhttp3|
-|kotlin|org.apache.hadoop.thirdparty.io.jaegertracing.kotlin|
-|org.intellij|org.apache.hadoop.thirdparty.io.jaegertracing.org.intellij|
-|org.jetbrains|org.apache.hadoop.thirdparty.io.jaegertracing.org.jetbrains|
-|okio|org.apache.hadoop.thirdparty.io.jaegertracing.okio|


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HADOOP-17707