### PR TITLE
HADOOP-17730. Add back error_prone

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -207,6 +207,7 @@ License Version 2.0:
 
 com.google.guava:guava:jar:30.1.1-jre
 com.google.j2objc:j2objc-annotations:1.3
+com.google.errorprone:error_prone_annotations:2.5.1
 
 --------------------------------------------------------------------------------
 This product bundles various third-party components under other open source

--- a/hadoop-shaded-guava/pom.xml
+++ b/hadoop-shaded-guava/pom.xml
@@ -36,13 +36,6 @@
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <version>${guava.version}</version>
-            <exclusions>
-                <!-- Excluding error_prone_annotations because of YARN-10195-->
-                <exclusion>
-                    <groupId>com.google.errorprone</groupId>
-                    <artifactId>error_prone_annotations</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
     </dependencies>
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -59,5 +59,5 @@ Following are relocations under *hadoop-shaded-guava* artifact:
 
 |Original package | Shaded package |
 |---|---|
-|com.google.guava|org.apache.hadoop.thirdparty.com.google|
+|com.google|org.apache.hadoop.thirdparty.com.google|
 |org.checkerframework|org.apache.hadoop.thirdparty.org.checkerframework|


### PR DESCRIPTION
Tested by compiling Ozone with the modified Hadoop-thirdparty 1.1.0