### PR TITLE
HADOOP-18197. Upgrade protobuf to 3.21.7

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -217,7 +217,7 @@ See licenses-binary/ for text of these licenses.
 
 BSD 3-Clause
 ------------
-com.google.protobuf:protobuf-java:3.20.1
+com.google.protobuf:protobuf-java:3.21.1
 
 
 MIT License

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -217,7 +217,7 @@ See licenses-binary/ for text of these licenses.
 
 BSD 3-Clause
 ------------
-com.google.protobuf:protobuf-java:3.21.1
+com.google.protobuf:protobuf-java:3.21.7
 
 
 MIT License

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -217,7 +217,7 @@ See licenses-binary/ for text of these licenses.
 
 BSD 3-Clause
 ------------
-com.google.protobuf:protobuf-java:3.7.1
+com.google.protobuf:protobuf-java:3.20.1
 
 
 MIT License

--- a/hadoop-shaded-guava/pom.xml
+++ b/hadoop-shaded-guava/pom.xml
@@ -24,7 +24,7 @@
         <artifactId>hadoop-thirdparty</artifactId>
         <groupId>org.apache.hadoop.thirdparty</groupId>
         <version>1.2.0-SNAPSHOT</version>
-        <relativePath>..</relativePath>
+        <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>hadoop-shaded-guava</artifactId>

--- a/hadoop-shaded-protobuf_3_21/pom.xml
+++ b/hadoop-shaded-protobuf_3_21/pom.xml
@@ -27,7 +27,7 @@
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
+  <artifactId>hadoop-shaded-protobuf_3_21</artifactId>
   <name>Apache Hadoop shaded Protobuf</name>
   <packaging>jar</packaging>
 

--- a/hadoop-shaded-protobuf_3_7/pom.xml
+++ b/hadoop-shaded-protobuf_3_7/pom.xml
@@ -24,11 +24,11 @@
     <artifactId>hadoop-thirdparty</artifactId>
     <groupId>org.apache.hadoop.thirdparty</groupId>
     <version>1.2.0-SNAPSHOT</version>
-    <relativePath>..</relativePath>
+    <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
   <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
-  <name>Apache Hadoop shaded Protobuf 3.7</name>
+  <name>Apache Hadoop shaded Protobuf</name>
   <packaging>jar</packaging>
 
   <properties>
@@ -38,7 +38,7 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <version>${protobuf_3_7.version}</version>
+      <version>${protobuf_3.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!--thirdparty dependency versions-->
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-    <protobuf_3.version>3.21.1</protobuf_3.version>
+    <protobuf_3.version>3.21.7</protobuf_3.version>
     <guava.version>30.1.1-jre</guava.version>
 
     <!-- maven plugin versions -->
@@ -122,7 +122,7 @@
   </organization>
 
   <modules>
-    <module>hadoop-shaded-protobuf_3_7</module>
+    <module>hadoop-shaded-protobuf_3_21</module>
     <module>hadoop-shaded-guava</module>
   </modules>
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!--thirdparty dependency versions-->
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-    <protobuf_3.version>3.20.1</protobuf_3.version>
+    <protobuf_3.version>3.21.1</protobuf_3.version>
     <guava.version>30.1.1-jre</guava.version>
 
     <!-- maven plugin versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!--thirdparty dependency versions-->
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
-    <protobuf_3_7.version>3.7.1</protobuf_3_7.version>
+    <protobuf_3.version>3.20.1</protobuf_3.version>
     <guava.version>30.1.1-jre</guava.version>
 
     <!-- maven plugin versions -->

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -42,7 +42,7 @@ This page provides an overview of the major changes.
 
 Protobuf-java
 -------------
-Google Protobuf's 3.7.1 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7* artifact.
+Google Protobuf's 3.21.1 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7* artifact.
 
 Following are relocations under *hadoop-shaded-protobuf_3_7* artifact:
 

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -42,9 +42,9 @@ This page provides an overview of the major changes.
 
 Protobuf-java
 -------------
-Google Protobuf's 3.21.1 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_7* artifact.
+Google Protobuf's 3.21.7 jar is available as *org.apache.hadoop.thirdparty:hadoop-shaded-protobuf_3_21* artifact.
 
-Following are relocations under *hadoop-shaded-protobuf_3_7* artifact:
+Following are relocations under *hadoop-shaded-protobuf_3_21* artifact:
 
 |Original package | Shaded package |
 |---|---|


### PR DESCRIPTION
This patch bumps up the protobuf version so that Hadoop
is not a vulnerable to CVE-2021-22569.


This also fixes up the parent POM references in the child modules
as IntelliJ requires a full path.

Testing: needs to go through hadoop built with the updated jar and
with its own protobuf version marker updated.
Verified hadoop compiles on a macbook m1.
