### PR TITLE
HADOOP-18843. Guava version 32.0.1 bump to fix CVE-2023-2976

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "java.compile.nullAnalysis.mode": "automatic"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "java.compile.nullAnalysis.mode": "automatic"
-}

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,7 +205,7 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-com.google.guava:guava:jar:31.1-jre
+com.google.guava:guava:jar:32.0.1-jre
 com.google.j2objc:j2objc-annotations:1.3
 com.google.errorprone:error_prone_annotations:2.5.1
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
     <protobuf_3_7.version>3.7.1</protobuf_3_7.version>
-    <guava.version>31.1-jre</guava.version>
+    <guava.version>32.0.1-jre</guava.version>
     <avro.version>1.11.1</avro.version>
 
     <!-- maven plugin versions -->


### PR DESCRIPTION
Bumping guava version to 32.0.1-jre to fix [CVE-2023-2976](https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2023-2976)
