### PR TITLE
HADOOP-19063. [thirdparty] Fix the docker image setuptools-scm && lazy-object-proxy.

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -125,6 +125,8 @@ ENV FINDBUGS_HOME /usr
 ####
 RUN pip2 install isort==4.3.21
 RUN pip2 install pylint==1.9.2
+RUN pip2 install setuptools-scm==5.0.2
+RUN pip2 install lazy-object-proxy==1.5.0
 
 ####
 # Install dateutil.parser


### PR DESCRIPTION
## Jira
JIRA: HADOOP-19063. [thirdparty] Fix the docker image setuptools-scm && lazy-object-proxy.

## Describe

When compiling the docker-image, I found that the Dockerfile failed to execute pip install setuptools-scm && pip install lazy-object-proxy. This is because setuptools-scm && lazy-object-proxy has been upgraded many times and currently no longer supports python2.7.

- setuptools-scm 
https://pypi.org/project/setuptools-scm/#history

- lazy-object-proxy
https://pypi.org/project/lazy-object-proxy/#history

I have consulted the release history lists of setuptools-scm and lazy-object-proxy, and I have found two versions that can be successfully installed. I have tested these two versions and confirmed that they can be installed properly and function correctly.

```
setuptools-scm==5.0.2
lazy-object-proxy==1.5.0
```