### PR TITLE
HADOOP-19064. [thirdparty] add -mvnargs option to create-release command line.

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -241,6 +241,7 @@ function usage
   echo "--security              Emergency security release"
   echo "--sign                  Use .gnupg dir to sign the artifacts and jars"
   echo "--version=[version]     Use an alternative version string"
+  echo "--mvnargs=[args]        Extra Maven args to be provided when running mvn commands"
 }
 
 function option_parse
@@ -290,6 +291,9 @@ function option_parse
       ;;
       --version=*)
         HADOOP_THIRDPARTY_VERSION=${i#*=}
+      ;;
+      --mvnargs=*)
+        MVNEXTRAARGS=${i#*=}
       ;;
     esac
   done
@@ -356,6 +360,10 @@ function option_parse
     if [[ -d "${MVNCACHE}" ]]; then
       MVN_ARGS=("-Dmaven.repo.local=${MVNCACHE}")
     fi
+  fi
+
+  if [ -n "$MVNEXTRAARGS" ]; then
+    MVN_ARGS+=("$MVNEXTRAARGS")
   fi
 
   if [[ "${SECURITYRELEASE}" = true ]]; then


### PR DESCRIPTION
## JIRA
JIRA: https://issues.apache.org/jira/browse/HADOOP-19064

## Describe

I compiled according to the how to release document, and I encountered the following error:

```
[ESC[1;31mERRORESC[m] Failed to execute goal ESC[32morg.apache.maven.plugins:maven-deploy-plugin:2.8.1:deployESC[m ESC[1m(default-deploy)ESC[m on project ESC[36mhadoop-thirdpartyESC[m: ESC[1;31mFailed to deploy artifacts: Could not transfer artifact org.apache.hadoop.thirdparty:hadoop-thirdparty:pom:1.2.0 from/to apache.staging.https (https://repository.apache.org/service/local/staging/deploy/maven2): Failed to transfer file: https://repository.apache.org/service/local/staging/deploy/maven2/org/apache/hadoop/thirdparty/hadoop-thirdparty/1.2.0/hadoop-thirdparty-1.2.0.pom. 
Return code is: 401, ReasonPhrase: Unauthorized.ESC[m -> ESC[1m[Help 1]ESC[m
```

I cannot upload the compiled jar package to maven staging dir.  I carefully checked the permissions and used curl to upload directly, and found that it could be uploaded, which shows that the account number and password are accurate. 
The related issue should be a maven configuration issue.

I use the following command to log in to the image and use `mvn -X` to check
```
docker run -i -t --privileged -v /root/.gnupg:/home/root/.gnupg -v /hadoop/hadoop-thirdparty/patchprocess:/hadoop/hadoop-thirdparty/patchprocess -v /hadoop/hadoop-thirdparty/target/artifacts:/hadoop/hadoop-thirdparty/target/artifacts -v /root/.m2/settings.xml:/home/root/.m2/settings.xml -v /hadoop/hadoop-thirdparty:/build/source -u root -w /build/source hadoop/createrelease:1.2.0_18569/bin/bash
```


We will map the `setting.xml` using the following command:

```
-v /root/.m2/settings.xml:/home/root/.m2/settings.xml
```

- mvn -X

We can find that maven does not read the `setting.xml` file under the root home directory.

```
[DEBUG] Reading global settings from /usr/share/maven/conf/settings.xml
[DEBUG] Reading user settings from /root/.m2/settings.xml
[DEBUG] Reading global toolchains from /usr/share/maven/conf/toolchains.xml
[DEBUG] Reading user toolchains from /root/.m2/toolchains.xml
[DEBUG] Using local repository at /root/.m2/repository
```

The reason why it cannot be uploaded is that we expected maven to read `/home/root/.m2/settings.xml`, but maven actually read `/root/.m2/settings.xml` because in `/root/.m2/` is not configured, so Maven chooses the global configuration `/usr/share/maven/conf/settings.xml`, and the apache account and password are not read.

> Solution 1

I used a solution in the Dockerfile by adding `RUN rm -f /etc/maven/settings.xml && ln -s /home/root/.m2/settings.xml `/etc/maven/settings.xml. This solution resolves the issue with file uploads, but it causes a diff between the src files and tags.

> Solution 2

I can use `mvn -D` to specify `user.home` to solve the problem of reading the configuration file.  
This method also works, so I backport HADOOP-18198.

```
dev-support/bin/create-release --asfrelease --docker --dockercache --mvnargs="-Duser.home=/home/root"
```