### PR TITLE
[BUILD] upgrade GitHub actions because old versions no longer work reliably

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Build with Maven
       run: mvn install
 

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: Dependency check with Maven
       run: mvn dependency-check:aggregate
     - name: Upload the report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: dependency-check-report
         path: "**/target/dependency-check-report.html"

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -24,16 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout source
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up JDK 8
-      uses: actions/setup-java@v2
+      uses: actions/setup-java@v4
       with:
         java-version: '8'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: License check with Maven
       run: mvn apache-rat:check
     - name: Upload the report
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: license-check-report
         path: "**/target/rat.txt"


### PR DESCRIPTION
See broken build for #38 

Example:

The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2, actions/setup-java@v2. For more info: https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default


GitHub are removing support for Node 16 (and older) and the old CI actions used by this project use Node 12 and 16.

'adopt' JDKs have been rebranded as 'temurin' - https://adoptium.net/en-GB/temurin/releases/ 
