### PR TITLE
HADOOP-19360. Disable releases for apache.snapshots repo

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,9 @@
       <id>${distMgmtSnapshotsId}</id>
       <name>${distMgmtSnapshotsName}</name>
       <url>${distMgmtSnapshotsUrl}</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
     </repository>
     <repository>
       <id>repository.jboss.org</id>


### PR DESCRIPTION
## What changes were proposed in this pull request?

The Apache snapshot repository should be enabled only for snapshots.

```
Downloading from apache.snapshots.https: https://repository.apache.org/content/repositories/snapshots/com/google/protobuf/protobuf-java/3.25.5/protobuf-java-3.25.5.pom
```

https://github.com/apache/hadoop-thirdparty/actions/runs/11588886714/job/32263341813#step:4:9755

https://issues.apache.org/jira/browse/HADOOP-19360

## How was this patch tested?

local build