### PR TITLE
HADOOP-19700. hadoop-thirdparty build to update maven plugin dependencies

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,3 +4,15 @@ Please create an issue in ASF JIRA before opening a pull request,
 and you need to set the title of the pull request which starts with
 the corresponding JIRA issue number. (e.g. HADOOP-XXXXX. Fix a typo in YYY.)
 For more details, please see https://cwiki.apache.org/confluence/display/HADOOP/How+To+Contribute
+
+### For code changes:
+
+- [ ] Does the title or this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
+- [ ] Have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
+- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?
+
+### Use of AI
+
+Was AI used to help generate this PR?
+
+If so: which tool:

--- a/.github/workflows/dependency_check.yml
+++ b/.github/workflows/dependency_check.yml
@@ -6,7 +6,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#   http://www.apache.org/licenses/LICENSE-2.0
+#   https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
@@ -25,10 +25,10 @@ jobs:
     steps:
     - name: Checkout source
       uses: actions/checkout@v4
-    - name: Set up JDK 8
+    - name: Set up JDK
       uses: actions/setup-java@v4
       with:
-        java-version: '8'
+        java-version: '17'
         distribution: 'temurin'
     - name: Dependency check with Maven
       run: mvn dependency-check:aggregate

--- a/hadoop-shaded-avro_1_11/pom.xml
+++ b/hadoop-shaded-avro_1_11/pom.xml
@@ -8,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>hadoop-thirdparty</artifactId>
         <groupId>org.apache.hadoop.thirdparty</groupId>
@@ -32,11 +32,17 @@
     <packaging>jar</packaging>
 
     <dependencies>
-        <dependency>
-            <groupId>org.apache.avro</groupId>
-            <artifactId>avro</artifactId>
-            <version>${avro.version}</version>
-        </dependency>
+      <dependency>
+        <groupId>org.apache.avro</groupId>
+        <artifactId>avro</artifactId>
+        <version>${avro.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>*</groupId>
+            <artifactId>*</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
     </dependencies>
 
     <build>

--- a/hadoop-shaded-guava/pom.xml
+++ b/hadoop-shaded-guava/pom.xml
@@ -8,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>hadoop-thirdparty</artifactId>
         <groupId>org.apache.hadoop.thirdparty</groupId>

--- a/hadoop-shaded-protobuf_3_25/pom.xml
+++ b/hadoop-shaded-protobuf_3_25/pom.xml
@@ -8,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http//maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
     <artifactId>hadoop-thirdparty</artifactId>
     <groupId>org.apache.hadoop.thirdparty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
   "License"); you may not use this file except in compliance
   with the License.  You may obtain a copy of the License at
 
-    http://www.apache.org/licenses/LICENSE-2.0
+    https://www.apache.org/licenses/LICENSE-2.0
 
   Unless required by applicable law or agreed to in writing,
   software distributed under the License is distributed on an
@@ -19,7 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.apache.hadoop.thirdparty</groupId>
   <artifactId>hadoop-thirdparty</artifactId>
@@ -101,6 +101,11 @@
     <guava.version>33.4.8-jre</guava.version>
     <avro.version>1.11.4</avro.version>
 
+    <!--
+      Transient dependencies which are not bundled but are depended on by those
+      artifacts.
+    -->
+
     <!-- maven plugin versions -->
     <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
     <maven-site-plugin.version>4.0.0-M8</maven-site-plugin.version>
@@ -116,8 +121,38 @@
     <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
     <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
     <checkstyle.version>10.12.7</checkstyle.version>
-    <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
+
     <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
+
+    <!--
+      OWASP's dependency-check plugin will scan the third party
+      dependencies of this project for known CVEs (security
+      vulnerabilities against them). It will produce a report
+      in target/dependency-check-report.html.
+
+      To invoke, run
+        mvn dependency-check:aggregate
+      on a java11+ runtime (even if you still release on java8)
+
+      This is a slow process due to the download of the CVE list; pushing a draft PR
+      up is generally a better strategy except when working on the build process itself.
+
+      See: https://jeremylong.github.io/DependencyCheck/dependency-check-maven/
+     -->
+    <dependency-check-maven.version>12.1.5</dependency-check-maven.version>
+    <!--
+      NVD API key. Without this downloads are slower and may be throttled.
+
+      Request one from https://nvd.nist.gov/developers/request-an-api-key
+      Set on the maven command line
+        mvn dependency-check:aggregate -Dnvd.api.key=081404c1-37e3-48f2-849d-d0f779f48ef2
+    -->
+    <nvd.api.key></nvd.api.key>
+
+    <!--
+      Sonatype OSS requires a key, so is disabled.
+    -->
+    <sonatype.oss.enabled>false</sonatype.oss.enabled>
   </properties>
 
   <organization>
@@ -290,16 +325,16 @@
         <extensions>true</extensions>
       </plugin>
       <plugin>
-        <!-- OWASP's dependency-check plugin will scan the third party
-             dependencies of this project for known CVEs (security
-             vulnerabilities against them). It will produce a report
-             in target/dependency-check-report.html. To invoke, run
-             'mvn dependency-check:aggregate'. Note that this plugin
-             requires maven 3.1.1 or greater.
-        -->
         <groupId>org.owasp</groupId>
         <artifactId>dependency-check-maven</artifactId>
         <version>${dependency-check-maven.version}</version>
+        <configuration>
+          <nvdApiKey>${nvd.api.key}</nvdApiKey>
+          <!-- ignore artifacts not shaded -->
+          <skipProvidedScope>true</skipProvidedScope>
+          <!-- sonatype is optional -->
+          <ossindexAnalyzerEnabled>${sonatype.oss.enabled}</ossindexAnalyzerEnabled>
+        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,7 @@
     <maven-bundle-plugin.version>2.5.0</maven-bundle-plugin.version>
     <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
     <checkstyle.version>8.19</checkstyle.version>
-    <dependency-check-maven.version>6.1.5</dependency-check-maven.version>
+    <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
     <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,22 +102,22 @@
     <avro.version>1.11.4</avro.version>
 
     <!-- maven plugin versions -->
-    <maven-deploy-plugin.version>2.8.1</maven-deploy-plugin.version>
-    <maven-site-plugin.version>3.6</maven-site-plugin.version>
-    <maven-stylus-skin.version>1.5</maven-stylus-skin.version>
-    <maven-antrun-plugin.version>1.7</maven-antrun-plugin.version>
-    <maven-assembly-plugin.version>2.5</maven-assembly-plugin.version>
-    <maven-dependency-plugin.version>3.0.2</maven-dependency-plugin.version>
-    <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
-    <maven-javadoc-plugin.version>3.0.1</maven-javadoc-plugin.version>
-    <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
-    <apache-rat-plugin.version>0.12</apache-rat-plugin.version>
-    <wagon-ssh.version>2.4</wagon-ssh.version>
-    <maven-bundle-plugin.version>2.5.0</maven-bundle-plugin.version>
-    <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
-    <checkstyle.version>8.19</checkstyle.version>
+    <maven-deploy-plugin.version>3.1.1</maven-deploy-plugin.version>
+    <maven-site-plugin.version>4.0.0-M8</maven-site-plugin.version>
+    <maven-stylus-skin.version>1.6</maven-stylus-skin.version>
+    <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
+    <maven-dependency-plugin.version>3.6.0</maven-dependency-plugin.version>
+    <maven-enforcer-plugin.version>3.4.1</maven-enforcer-plugin.version>
+    <maven-javadoc-plugin.version>3.5.0</maven-javadoc-plugin.version>
+    <maven-gpg-plugin.version>3.0.1</maven-gpg-plugin.version>
+    <apache-rat-plugin.version>0.16</apache-rat-plugin.version>
+    <wagon-ssh.version>3.5.3</wagon-ssh.version>
+    <maven-bundle-plugin.version>5.1.8</maven-bundle-plugin.version>
+    <maven-checkstyle-plugin.version>3.3.0</maven-checkstyle-plugin.version>
+    <checkstyle.version>10.12.7</checkstyle.version>
     <dependency-check-maven.version>10.0.2</dependency-check-maven.version>
-    <exec-maven-plugin.version>1.3.1</exec-maven-plugin.version>
+    <exec-maven-plugin.version>3.2.0</exec-maven-plugin.version>
   </properties>
 
   <organization>
@@ -146,7 +146,7 @@
           <configuration>
             <rules>
               <requireMavenVersion>
-                <version>[3.0.2,)</version>
+                <version>[3.3.0,)</version>
               </requireMavenVersion>
               <requireJavaVersion>
                 <version>[1.8,)</version>


### PR DESCRIPTION

* dependency-checker goes to 12.1.5
* maven min build set to 3.3.0 (manual)
* all other plugins updated by copilot.

dependency-checker is the main bit of work; #45 showed it was broken.

The version now works, prefers a vulnerability api key from nvd; this can be passed down though the default of "" works. The sonatype OSS scan is disabled as it is key only and there's no obvious easy way to to pass this in.

As the version is java11 only, the matching github action has been updated.

Also some housekeeping
* move to https urls for apache license and XSD in the pom files
* change PR text to call out updating LICENSE-binary *and* whether AI was used. We have to do that now, FYI.