### PR TITLE
HADOOP-19832 Fix missing relocation for org.jspecify in hadoop-shaded-guava

### DIFF
--- a/hadoop-shaded-guava/pom.xml
+++ b/hadoop-shaded-guava/pom.xml
@@ -130,6 +130,10 @@
                                     <pattern>org/checkerframework/</pattern>
                                     <shadedPattern>${shaded.prefix}/org/checkerframework/</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>org/jspecify/</pattern>
+                                    <shadedPattern>${shaded.prefix}/org/jspecify/</shadedPattern>
+                                </relocation>
                             </relocations>
                             <transformers>
                                 <transformer


### PR DESCRIPTION
Closes https://issues.apache.org/jira/browse/HADOOP-19832

## Problem

`org.jspecify:jspecify` was added as a shaded artifact in 1.5.0 but without a corresponding relocation rule. As a result, its classes are bundled at their original `org/jspecify/annotations/` path inside the `hadoop-shaded-guava` jar.

This causes classpath collisions in projects that also have a direct or transitive dependency on `org.jspecify:jspecify`, since the same class files appear from two different jars.

## Fix

Add a `<relocation>` rule for `org/jspecify/` in the `maven-shade-plugin` configuration, consistent with how `com/google/` and `org/checkerframework/` are already handled.

---

### For code changes:

- [x] Does the title or this PR start with the corresponding JIRA issue id?
- [x] Have you updated the \`LICENSE\`, \`LICENSE-binary\`, \`NOTICE-binary\` files? — No new dependencies added; this fix only adds a relocation rule for an already-included artifact
- [x] If adding new dependencies to the code, are these compatible with [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)? — No new dependencies added

### Use of AI

Yes — Claude (Anthropic) was used to help identify the root cause and draft this fix.