### PR TITLE
HADOOP-19841. hadoop-thirdparty: upgrade to avro 1.11.5

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -210,7 +210,7 @@ com.google.guava:failureaccess:jar:1.0.3
 org.jspecify:jspecify:jar:1.0.0
 com.google.errorprone:error_prone_annotations:jar:2.36.0
 com.google.j2objc:j2objc-annotations:jar:3.0.0
-org.apache.avro:avro:1.11.4
+org.apache.avro:avro:1.11.5
 
 --------------------------------------------------------------------------------
 This product bundles various third-party components under other open source

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
     <guava.version>33.4.8-jre</guava.version>
     <!-- previous versions of guava included this, but they've stopped it. We reinsert it to the shaded guava artifact-->
     <checkerframework.version>3.51.1</checkerframework.version>
-    <avro.version>1.11.4</avro.version>
+    <avro.version>1.11.5</avro.version>
 
     <!--
       Transient dependencies which are not bundled but are depended on by those


### PR DESCRIPTION

Bumps the shaded Avro dependency to the latest 1.11.x patch release.

### For code changes:

- [X] Does the title or this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
- [ ] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?

### Use of AI

Was AI used to help generate this PR? yes, actually. It forgot about the license/notice changes first time round.

If so: which tool: Claude