### PR TITLE
HADOOP-19842. hadoop-thirdparty: upgrade guava to 33.5.0-jre

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -205,11 +205,11 @@
 This project bundles some components that are also licensed under the Apache
 License Version 2.0:
 
-com.google.guava:guava:jar:33.4.8-jre
+com.google.guava:guava:jar:33.5.0-jre
 com.google.guava:failureaccess:jar:1.0.3
 org.jspecify:jspecify:jar:1.0.0
-com.google.errorprone:error_prone_annotations:jar:2.36.0
-com.google.j2objc:j2objc-annotations:jar:3.0.0
+com.google.errorprone:error_prone_annotations:jar:2.41.0
+com.google.j2objc:j2objc-annotations:jar:3.1
 org.apache.avro:avro:1.11.5
 
 --------------------------------------------------------------------------------
@@ -225,4 +225,4 @@ com.google.protobuf:protobuf-java:3.25.8
 
 MIT License
 -----------
-org.checkerframework:checker-qual:jar:3.51.1
+org.checkerframework:checker-qual:jar:3.54.0

--- a/pom.xml
+++ b/pom.xml
@@ -98,7 +98,7 @@
     <shaded.prefix>org.apache.hadoop.thirdparty</shaded.prefix>
     <protobuf.shade.prefix>${shaded.prefix}.protobuf</protobuf.shade.prefix>
     <protobuf_3.version>3.25.8</protobuf_3.version>
-    <guava.version>33.4.8-jre</guava.version>
+    <guava.version>33.5.0-jre</guava.version>
     <!-- previous versions of guava included this, but they've stopped it. We reinsert it to the shaded guava artifact-->
     <checkerframework.version>3.51.1</checkerframework.version>
     <avro.version>1.11.5</avro.version>


### PR DESCRIPTION

Upgrade Guava from 33.4.8-jre to 33.5.0-jre and Checker Framework from 3.51.1 to 3.54.0

Bumps the shaded Guava dependency to the latest release and updates the bundled Checker Framework qualifier annotations accordingly. Updates LICENSE-binary to reflect new versions of guava, checker-qual, error_prone_annotations (2.36.0 -> 2.41.0), and j2objc-annotations (3.0.0 -> 3.1).

### For code changes:

- [X] Does the title or this PR start with the corresponding JIRA issue id (e.g. 'HADOOP-17799. Your PR title ...')?
- [X] Have you updated the `LICENSE`, `LICENSE-binary`, `NOTICE-binary` files?
- [X] If adding new dependencies to the code, are these dependencies licensed in a way that is compatible for inclusion under [ASF 2.0](https://www.apache.org/legal/resolved.html#category-a)?

### Use of AI

Was AI used to help generate this PR? Yes

If so: which tool: Claude

it ran maven dependencies to get those updated dependencies too; it says some were new