### PR TITLE
HADOOP-19840. Release hadoop-thirdparty 1.6.0: docker setup for mac and maven 3.9.12

### DIFF
--- a/dev-support/bin/create-release
+++ b/dev-support/bin/create-release
@@ -196,6 +196,14 @@ function set_defaults
 function startgpgagent
 {
   if [[ "${SIGN}" = true ]]; then
+    # When running inside Docker on macOS, ~/.gnupg is a tmpfs (to support
+    # Unix domain sockets). Copy keys from the read-only staging mount.
+    if [[ "${INDOCKER}" = true && -d /gnupg-source ]]; then
+      cp -r /gnupg-source/. "${HOME}/.gnupg/"
+      chmod 700 "${HOME}/.gnupg"
+      echo "allow-loopback-pinentry" >> "${HOME}/.gnupg/gpg-agent.conf"
+    fi
+
     if [[ -n "${GPGAGENT}" && -z "${GPG_AGENT_INFO}" ]]; then
       echo "starting gpg agent"
       echo "default-cache-ttl 36000" > "${LOGDIR}/gpgagent.conf"
@@ -395,7 +403,11 @@ function dockermode
   imgname="hadoop/createrelease:${HADOOP_THIRDPARTY_VERSION}_${RANDOM}"
 
   if [[ -d "${HOME}/.gnupg" ]]; then
-    extrad+=("-v" "${HOME}/.gnupg:/home/${user_name}/.gnupg")
+    # Mount gnupg files read-only at a staging path; the actual ~/.gnupg is a
+    # tmpfs so that gpg-agent can bind its Unix domain socket there (macOS
+    # volume mounts do not support Unix sockets).
+    extrad+=("-v" "${HOME}/.gnupg:/gnupg-source:ro")
+    extrad+=("--tmpfs" "/home/${user_name}/.gnupg:exec,mode=700,uid=${user_id},gid=${group_id}")
   fi
 
   if [[ -n "${LOGDIR}" ]]; then
@@ -458,7 +470,9 @@ function dockermode
 
     # we always force build with the OpenJDK JDK
     # but with the correct version
-    echo "ENV JAVA_HOME /usr/lib/jvm/java-${JVM_VERSION}-openjdk-amd64"
+    # Use a symlink to support both amd64 and arm64 builds
+    echo "RUN ln -sf \$(ls -d /usr/lib/jvm/java-${JVM_VERSION}-openjdk-* | head -1) /usr/lib/jvm/java-${JVM_VERSION}-openjdk-current"
+    echo "ENV JAVA_HOME /usr/lib/jvm/java-${JVM_VERSION}-openjdk-current"
     echo "USER ${user_name}"
     printf "\n\n"
   ) | docker build -t "${imgname}" -

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -93,16 +93,22 @@ RUN apt-get -q update \
     && rm -rf /var/lib/apt/lists/*
 
 ######
-# Install Apache Maven 3.6.0 (3.6.0 ships with Bionic)
+# Install Apache Maven 3.9.12 (Ubuntu Bionic ships 3.6.0 which is too old;
+# pom.xml requires [3.6.3,))
 ######
-# hadolint ignore=DL3008
-RUN apt-get -q update \
-    && apt-get -q install -y --no-install-recommends maven \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-ENV MAVEN_HOME /usr
+RUN curl -s -S -o /tmp/maven.tar.gz \
+        "https://archive.apache.org/dist/maven/maven-3/3.9.12/binaries/apache-maven-3.9.12-bin.tar.gz" \
+    && echo "0a1be79f02466533fc1a80abbef8796e4f737c46c6574ede5658b110899942a94db634477dfd3745501c80aef9aac0d4f841d38574373f7e2d24cce89d694f70  /tmp/maven.tar.gz" \
+        | sha512sum -c - \
+    && tar -xz -C /opt -f /tmp/maven.tar.gz \
+    && rm /tmp/maven.tar.gz \
+    && ln -sf /opt/apache-maven-3.9.12/bin/mvn /usr/bin/mvn \
+    && ln -sf /opt/apache-maven-3.9.12/bin/mvnDebug /usr/bin/mvnDebug
+ENV MAVEN_HOME /opt/apache-maven-3.9.12
 # JAVA_HOME must be set in Maven >= 3.5.0 (MNG-6003)
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64
+# Use a symlink to support both amd64 and arm64 builds
+RUN ln -sf "$(ls -d /usr/lib/jvm/java-8-openjdk-* | head -1)" /usr/lib/jvm/java-8-openjdk
+ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk
 
 ######
 # Install findbugs 3.1.0 (3.1.0 ships with Bionic)
@@ -125,7 +131,8 @@ ENV FINDBUGS_HOME /usr
 ####
 RUN pip2 install isort==4.3.21
 RUN pip2 install setuptools-scm==5.0.2
-RUN pip2 install lazy-object-proxy==1.5.0
+RUN pip2 install wrapt==1.11.2
+RUN pip2 install lazy-object-proxy==1.4.3
 RUN pip2 install pylint==1.9.2
 
 ####
@@ -156,6 +163,8 @@ ENV MAVEN_OPTS -Xms256m -Xmx1536m
 
 # Hugo static website generator (for new hadoop site and Ozone docs)
 RUN curl -L -o hugo.deb https://github.com/gohugoio/hugo/releases/download/v0.30.2/hugo_0.30.2_Linux-64bit.deb \
+    && echo "4a63254d90fb44722d4dabd0a935f749248b9cf182740480836a53f27c30d90df13895361512af204382d8b8cc76aacadbbddd77d99aa8b93608d8e1ece021eb  hugo.deb" \
+        | sha512sum -c - \
     && dpkg --install hugo.deb \
     && rm hugo.deb
 


### PR DESCRIPTION
Fix release tooling for macOS (Apple Silicon) support:
- Dockerfile: install Maven 3.9.12 (Bionic ships 3.6.0, below the required 3.6.3 minimum); validate SHA-512 checksum
- Dockerfile: set JAVA_HOME via arch-aware symlink to support both amd64 and arm64
- Dockerfile: pin wrapt==1.11.2 and lazy-object-proxy==1.4.3 to avoid Python 2.7 incompatible setup.cfg attr: version parsing
- Dockerfile: validate Hugo 0.30.2 .deb SHA-512 checksum
- create-release: fix JAVA_HOME to use arch-aware symlink (script overrides Dockerfile value)
- create-release: mount ~/.gnupg read-only at /gnupg-source and provide a tmpfs at ~/.gnupg with correct uid/gid so gpg-agent can bind its Unix domain socket (macOS volume mounts do not support Unix domain sockets)

---

most of this was done with copilot + claude model; it works on the mac, but I need yetus
to see if it runs too. The fact that the maven upgrade was broken on docker is interesting, as it implies that yetus isn't building through docker.
